### PR TITLE
Specifies html5 doctype in CopyAsHTML. Closes issue #6.

### DIFF
--- a/src/CopyAsHtml/CopyAsHtml/ClipboardSupport.cs
+++ b/src/CopyAsHtml/CopyAsHtml/ClipboardSupport.cs
@@ -94,7 +94,7 @@ EndSelection:<<<<<<<4
 ";
 
             string pre =
-    @"<!DOCTYPE HTML PUBLIC ""-//W3C//DTD HTML 4.0 Transitional//EN"">
+    @"<!DOCTYPE html>
 <HTML><HEAD><TITLE>Snippet</TITLE></HEAD><BODY><!--StartFragment-->";
 
             string post = @"<!--EndFragment--></BODY></HTML>";


### PR DESCRIPTION
Simple change to update the HTML doctype to
`<!DOCTYPE html>`
