### PR TITLE
Add CopyAsHTMLTests project back to the main solution

### DIFF
--- a/src/CopyAsHtml/CopyAsHtmlTest/CopyAsHtmlTest.csproj
+++ b/src/CopyAsHtml/CopyAsHtmlTest/CopyAsHtmlTest.csproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -11,7 +11,6 @@
     <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
-    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/src/CopyAsHtml/CopyAsHtmlTest/CopyAsHtmlTest.csproj
+++ b/src/CopyAsHtml/CopyAsHtmlTest/CopyAsHtmlTest.csproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -8,9 +8,10 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>CopyAsHtmlTest</RootNamespace>
     <AssemblyName>CopyAsHtmlTest</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -30,12 +31,13 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.VisualStudio.CoreUtility, Version=12.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+    <Reference Include="Microsoft.VisualStudio.CoreUtility" />
     <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework" />
-    <Reference Include="Microsoft.VisualStudio.Text.Data, Version=12.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
-    <Reference Include="Microsoft.VisualStudio.Text.Logic, Version=12.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
-    <Reference Include="Microsoft.VisualStudio.Text.UI, Version=12.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
-    <Reference Include="Microsoft.VisualStudio.Text.UI.Wpf, Version=12.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+    <Reference Include="Microsoft.VisualStudio.Text.Data" />
+    <Reference Include="Microsoft.VisualStudio.Text.Logic" />
+    <Reference Include="Microsoft.VisualStudio.Text.UI" />
+    <Reference Include="Microsoft.VisualStudio.Text.UI.Wpf" />
+    <Reference Include="Microsoft.VisualStudio.Text.Internal" />
     <Reference Include="PresentationCore" />
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.Composition" />
@@ -55,7 +57,7 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\CopyAsHtml\CopyAsHtml.csproj">
-      <Project>{E53E2E8A-8975-43EA-BDCC-8966AE402520}</Project>
+      <Project>{e53e2e8a-8975-43ea-bdcc-8966ae402520}</Project>
       <Name>CopyAsHtml</Name>
     </ProjectReference>
   </ItemGroup>

--- a/src/CopyAsHtml/CopyAsHtmlTest/FormattedStringBuilderTests.cs
+++ b/src/CopyAsHtml/CopyAsHtmlTest/FormattedStringBuilderTests.cs
@@ -21,7 +21,8 @@ namespace CopyAsHtmlTest
             var formattedStringBuilder = new FormattedStringBuilder(
                 htmlMarkupProvider,
                 classifier,
-                MockClassificationType.Default);
+                MockClassificationType.Default,
+                waitIndicator: null);
 
             var snapshot = new MockTextSnapshot("bla");
             var spans = new NormalizedSnapshotSpanCollection(new [] 

--- a/src/ProPowerTools.Open.sln
+++ b/src/ProPowerTools.Open.sln
@@ -40,6 +40,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Structure Visualizer", "Str
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MiddleClickScroll", "MiddleClickScroll\MiddleClickScroll.csproj", "{EB4E0065-033F-4C44-B5C4-071C799FD931}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CopyAsHtmlTest", "CopyAsHtml\CopyAsHtmlTest\CopyAsHtmlTest.csproj", "{EBF2DB98-AFE4-44AD-BC37-1C81F27F4A49}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -106,6 +108,10 @@ Global
 		{EB4E0065-033F-4C44-B5C4-071C799FD931}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{EB4E0065-033F-4C44-B5C4-071C799FD931}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{EB4E0065-033F-4C44-B5C4-071C799FD931}.Release|Any CPU.Build.0 = Release|Any CPU
+		{EBF2DB98-AFE4-44AD-BC37-1C81F27F4A49}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{EBF2DB98-AFE4-44AD-BC37-1C81F27F4A49}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{EBF2DB98-AFE4-44AD-BC37-1C81F27F4A49}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{EBF2DB98-AFE4-44AD-BC37-1C81F27F4A49}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -119,5 +125,6 @@ Global
 		{1D7797BF-228B-4B3E-A1FA-9FB159E6CBDD} = {07322017-A09B-4948-8F0D-D8F359114AA3}
 		{38B9DE75-1DC7-4874-BFC7-7C6782E208F7} = {07322017-A09B-4948-8F0D-D8F359114AA3}
 		{E53E2E8A-8975-43EA-BDCC-8966AE402520} = {9EFF13ED-05C5-4F68-A9BE-750125FFDF41}
+		{EBF2DB98-AFE4-44AD-BC37-1C81F27F4A49} = {9EFF13ED-05C5-4F68-A9BE-750125FFDF41}
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
Somehow we lost CopyAsHTMLTests project. This adds it back to the solution.