### PR TITLE
Add support for Visual Studio 15 a.k.a 15.0

### DIFF
--- a/src/CopyAsHtml/CopyAsHtml/source.extension.vsixmanifest
+++ b/src/CopyAsHtml/CopyAsHtml/source.extension.vsixmanifest
@@ -6,7 +6,7 @@
     <Description>Adds support to copy the selected editor text to clipboard in HTML format.</Description>
   </Metadata>
   <Installation>
-    <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[14.0]" />
+    <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[14.0,15.0]" />
   </Installation>
   <Dependencies>
     <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />

--- a/src/FixMixedTabs/Impl/source.extension.vsixmanifest
+++ b/src/FixMixedTabs/Impl/source.extension.vsixmanifest
@@ -7,7 +7,7 @@
     <MoreInfo>http://blogs.msdn.com/noahric</MoreInfo>
   </Metadata>
   <Installation>
-    <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[14.0]" />
+    <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[14.0,15.0]" />
   </Installation>
   <Dependencies>
     <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />

--- a/src/GoToDef/source.extension.vsixmanifest
+++ b/src/GoToDef/source.extension.vsixmanifest
@@ -10,7 +10,7 @@ Also, when the ctrl key is held down, highlight identifiers that look like they 
     <PreviewImage>GoToDefinition-screenshot.png</PreviewImage>
   </Metadata>
   <Installation>
-    <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[14.0]" />
+    <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[14.0,15.0]" />
   </Installation>
   <Dependencies>
     <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />

--- a/src/MatchMargin/source.extension.vsixmanifest
+++ b/src/MatchMargin/source.extension.vsixmanifest
@@ -6,7 +6,7 @@
     <Description xml:space="preserve">This extension draws matchs that match the word under the caret in the scroll bar and in the editor.</Description>
   </Metadata>
   <Installation>
-    <InstallationTarget Version="[14.0,15.0)" Id="Microsoft.VisualStudio.Community" />
+    <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[14.0,15.0]" />
   </Installation>
   <Dependencies>
     <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="4.5" />

--- a/src/MiddleClickScroll/source.extension.vsixmanifest
+++ b/src/MiddleClickScroll/source.extension.vsixmanifest
@@ -6,7 +6,7 @@
     <Description>This is a sample viewport-relative adornment extension to the Visual Studio Editor.</Description>
   </Metadata>
   <Installation>
-    <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[14.0]" />
+    <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[14.0,15.0]" />
   </Installation>
   <Dependencies>
     <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />

--- a/src/OptionsPage/source.extension.vsixmanifest
+++ b/src/OptionsPage/source.extension.vsixmanifest
@@ -6,7 +6,7 @@
     <Description>Productivity Power Tools editor options page</Description>
   </Metadata>
   <Installation>
-    <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[14.0]" />
+    <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[14.0,15.0]" />
   </Installation>
   <Dependencies>
     <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />

--- a/src/PeekF1/src/source.extension.vsixmanifest
+++ b/src/PeekF1/src/source.extension.vsixmanifest
@@ -6,7 +6,7 @@
     <Description>Adds a command to Visual Studio to show F1 Help inline in the editor. By default the command is bound to Alt+F1.</Description>
   </Metadata>
   <Installation InstalledByMsi="false">
-    <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="14.0" />
+    <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[14.0,15.0]" />
   </Installation>
   <Dependencies>
     <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="4.5" />

--- a/src/Structure/StructureVisualizer/source.extension.vsixmanifest
+++ b/src/Structure/StructureVisualizer/source.extension.vsixmanifest
@@ -6,7 +6,7 @@
     <Description>This extension displays the block structure of code files.</Description>
   </Metadata>
   <Installation>
-    <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[14.0]" />
+    <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[14.0,15.0]" />
   </Installation>
   <Dependencies>
     <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />

--- a/src/SyntacticFisheye/source.extension.vsixmanifest
+++ b/src/SyntacticFisheye/source.extension.vsixmanifest
@@ -6,7 +6,7 @@
     <Description>This extension shrinks lines that contain neither text nor numbers so that more lines can be displayed in the editor.</Description>
   </Metadata>
   <Installation>
-    <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[14.0]" />
+    <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[14.0,15.0]" />
   </Installation>
   <Dependencies>
     <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />

--- a/src/TimeStampMargin/source.extension.vsixmanifest
+++ b/src/TimeStampMargin/source.extension.vsixmanifest
@@ -6,7 +6,7 @@
     <Description xml:space="preserve">This extension adds a time stamp margin to the debug output window.</Description>
   </Metadata>
   <Installation>
-    <InstallationTarget Version="[11.0,15.0)" Id="Microsoft.VisualStudio.Pro" />
+    <InstallationTarget Id="Microsoft.VisualStudio.Pro" Version="[14.0,15.0]" />
   </Installation>
   <Dependencies>
     <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="4.5" />


### PR DESCRIPTION
Hi,
regarding issue #20, I did it for you.
I updated supported versions from "only 14.0" (It's VS2015) to "both 14.0 and 15.0" (It's VS2015 and VS15)
I tried to install them on my local VS15 and all installed successfully.
I also tried using them and no errors came up.

But I guess this repo isn't full version of Productivity Power Tools right? Because the options in VS15 from installed built extensions locally has only "HTML Copy and Other Extensions" and in VS2015 from full package from VS Gallery it has more (Turn Extensions On/Off, Custom Document Well, PowerCommands and Solution Error Visualizer)
So when you will be creating new packed version of full PPT, please change the version for that main Extension also to [14.0,15.0] for it to support VS15 Preview.

Thank you!
Regards Jacob