### PR TITLE
Fix #39 disappearance of brace lines when the file contains expression-bodied property

### DIFF
--- a/src/Structure/BlockTaggerImpl/CsharpParser.cs
+++ b/src/Structure/BlockTaggerImpl/CsharpParser.cs
@@ -198,11 +198,12 @@ namespace Microsoft.PowerToolsEx.BlockTagger.Implementation
         private bool TryAsProperty(SyntaxNode childnode, ref BlockType type, ref int startPosition, ref int endPosition)
         {
             var child = childnode as PropertyDeclarationSyntax;
-            if (child != null)
+            var accessorList = child?.AccessorList;
+            if (accessorList != null)
             {
                 type = BlockType.Method;
-                startPosition = child.AccessorList.OpenBraceToken.SpanStart;
-                endPosition = child.AccessorList.CloseBraceToken.Span.End;
+                startPosition = accessorList.OpenBraceToken.SpanStart;
+                endPosition = accessorList.CloseBraceToken.Span.End;
 
                 return true;
             }


### PR DESCRIPTION
Fix issue #39
If the file contains expression-bodied property, Structure Visualizer does not display brace lines.
The null-check is added to avoid NullReferenceException.