### PR TITLE
Removed invalid link to PPT Options Page

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,5 +43,3 @@ You can download them here:
 * [Power Commands for Visual Studio](https://marketplace.visualstudio.com/items?itemName=VisualStudioProductTeam.PowerCommandsforVisualStudio)
 * [Shrink Empty Lines](https://marketplace.visualstudio.com/items?itemName=VisualStudioProductTeam.SyntacticLineCompression)
 * [Time Stamp Margin](https://marketplace.visualstudio.com/items?itemName=VisualStudioProductTeam.TimeStampMargin)
-* [PPT Options Page](https://marketplace.visualstudio.com/items?itemName=VisualStudioProductTeam.ProductivityPowerToolsOptionsPage)
-


### PR DESCRIPTION
PPT Options Page link is invalid, from marketplace description it looks like options page no longer exists.

`Note: The Productivity Power Tools does not install a page in Tools->Options for enabling and disabling individual Productivity Power Tools. For Visual Studio 2017, we have release all components as separate extensions. So, you can now enable and disable them through Extensions and Updates. Hence, there is no longer a need for the page in Tools->Options.`